### PR TITLE
[issue-4] 본인인증확인 기능 추가

### DIFF
--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/exception/ErrorCode.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/exception/ErrorCode.java
@@ -10,7 +10,10 @@ public enum ErrorCode {
   INTERNAL_SERVER_ERROR("1000", "서버 내부 에러입니다."),
 
   // 회원파트 에러 2000 ~ 2999
-  VERIFICATION_MAIL_CAN_SEND_IN_TERM("2000", "본인 확인 메일은 3분 간격으로 전송 가능합니다.");
+  VERIFICATION_MAIL_CAN_SEND_IN_TERM("2000", "본인인증 메일은 3분 간격으로 전송 가능합니다."),
+  VERIFICATION_MAIL_NOT_MATCH("2001", "본인인증 이메일이 일치하지 않습니다."),
+  VERIFICATION_FAILED("2002", "본인인증에 실패했습니다."),
+  VERIFICATION_EXCEED_TRY_COUNT("2003", "본인인증 시도 횟수를 초과하였습니다.");
 
   private final String code;
   private final String message;

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberController.java
@@ -1,7 +1,12 @@
 package com.kyumall.kyumallclient.member;
 
+import com.kyumall.kyumallclient.exception.ErrorCode;
+import com.kyumall.kyumallclient.exception.KyumallException;
+import com.kyumall.kyumallclient.member.dto.VerifySentCodeRequest;
+import com.kyumall.kyumallclient.response.ResponseWrapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,5 +25,21 @@ public class MemberController {
   @PostMapping("/send-verification-mail")
   public void sendVerificationMail(@RequestParam String email) {
     memberService.sendVerificationEmail(email);
+  }
+
+  /**
+   * 본인인증 코드와 일치하는지 검증합니다.
+   * @param request
+   * @return
+   */
+  @PostMapping("/verify-sent-code")
+  public void verifySentCode(@RequestBody VerifySentCodeRequest request) {
+    String result = memberService.verifySentCode(request);
+    // 트랜잭션 내에서 exception을 발생시키면 트랜잭션이 롤백 되어서 밖에서 처리하였습니다.
+    if (result.equals("FAIL")) {
+      throw new KyumallException(ErrorCode.VERIFICATION_FAILED);
+    } else if (result.equals("EXCEED_COUNT")) {
+      throw new KyumallException(ErrorCode.VERIFICATION_EXCEED_TRY_COUNT);
+    }
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/dto/VerifySentCodeRequest.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/dto/VerifySentCodeRequest.java
@@ -1,0 +1,11 @@
+package com.kyumall.kyumallclient.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class VerifySentCodeRequest {
+  private String email;
+  private String code;
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Verification.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Verification.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Verification extends BaseTimeEntity {
   private static final Integer SEND_RESTRICTED_PERIOD = 3;  // 메일 전송 쿨타임
+  private static final Integer MAX_TRY_COUNT = 3;
   private static final int VERIFICATION_CODE_SIZE = 6;  // 인증 코드 길이
 
   @Id
@@ -60,5 +61,30 @@ public class Verification extends BaseTimeEntity {
 
   public void expired() {
     status = VerificationStatus.EXPIRED;
+  }
+
+  public void verified() {
+    status = VerificationStatus.VERIFIED;
+  }
+
+  public boolean verify(String code) {
+    boolean isVerified = this.code.equals(code);
+    if (isVerified) {
+      verified();
+    }
+    return isVerified;
+  }
+
+  /**
+   * 인증 시도가 가능한지 체크합니다.
+   * tryCount 가 3회 미만이어야 합니다.
+   * @return
+   */
+  public boolean isUnderTryCount() {
+    return this.tryCount < MAX_TRY_COUNT;
+  }
+
+  public void increaseTryCount() {
+    tryCount += 1;
   }
 }

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/repository/VerificationRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/repository/VerificationRepository.java
@@ -11,4 +11,6 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
       + "where v.contact = :email "
       + "and v.status = 'UNVERIFIED'")
   Optional<Verification> findUnverifiedByEmail(String email);
+
+  Optional<Verification> findByContact(String email);
 }


### PR DESCRIPTION
## 변경사항
> 이메일로 전송된 인증번호를 사용하여 사용자가 인증을 받는 기능을 구현하였습니다.

## 시퀀스 다이어그램
<img width="610" alt="image" src="https://github.com/f-lab-edu/kyumall/assets/78974381/10d87dad-6c54-47ec-9291-c4ba876220d3">

## 테스트 케이스
- case1: 본인인증 성공
- case2: 본인인증 실패
- case3: 인증 실패 & 시도횟수 초과

## 리뷰어님께
- 예외를 던지면 트랜잭션이 롤백되어 변경 사항이 반영 안되는 문제점이 있어서.. @Transaction이 걸려 있는 Service 에서는 실패 시에 문자열 값을 반환하고, @Transaction이 없는 Controller 단에서 에러를 던지는 방식으로 했습니다.
