### PR TITLE
[issue 4] 약관조회로직 추가

### DIFF
--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/DataLoader.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/DataLoader.java
@@ -2,6 +2,7 @@ package com.kyumall.kyumallclient;
 
 import com.kyumall.kyumallcommon.member.entity.Term;
 import com.kyumall.kyumallcommon.member.repository.TermRepository;
+import com.kyumall.kyumallcommon.member.vo.TermStatus;
 import com.kyumall.kyumallcommon.member.vo.TermType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
@@ -23,17 +24,20 @@ public class DataLoader implements CommandLineRunner {
         .name("큐몰 이용약관")
         .content(
             "[ 큐몰 이용 약관 ] 제1장 총칙 제 1 조 (목적) 이 약관은 큐몰 주식회사(이하 “회사”)가 운영하는 사이버몰에서 제공하는 서비스와 이를 이용하는 회원의 권리·의무 및 책임사항을 규정함을 목적으로 합니다. 제 2 조 (용어의 정의) 이 약관에서 사용하는 용어의 정의는 다음과 같습니다. 그리고 여기에서 정의되지 않은 이 약관상의 용어의 의미는 일반적인 거래관행에 따릅니다. 1. “사이버몰”이란 회사가 상품 또는 용역 등(일정한 시설을 이용하거나 용역을 제공받을 수 있는 권리를 포함하며, 이하 “상품 등”)을 회원에게 제공하기 위하여 컴퓨터 등 정보통신설비를 이용하여 상품 등을 거래할 수 있도록 설정한 가상의 영업장 등 회사가 운영하는 웹사이트 및 모바일 웹, 앱 등을 모두 포함)을 의미합니다.")
-        .type(TermType.REQUIRED).build();
+        .type(TermType.REQUIRED)
+        .status(TermStatus.INUSE).build();
 
     Term privateInfoTerm = Term.builder()
         .name("개인정보 수집 및 이용 동의")
         .content("개인정 수집 및 이용에 동의합니다.")
-        .type(TermType.REQUIRED).build();
+        .type(TermType.REQUIRED)
+        .status(TermStatus.INUSE).build();
 
     Term marketingTerm = Term.builder()
         .name("마케팅 목적의 개인정보 수집 및 이용 동의 (선택)")
         .content("마케팅 목적으로 개인정보를 수집하고 이용하는 것에 동의합니다.")
-        .type(TermType.OPTIONAL).build();
+        .type(TermType.OPTIONAL)
+        .status(TermStatus.INUSE).build();
 
     termRepository.save(kyumallTerm);
     termRepository.save(privateInfoTerm);

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberController.java
@@ -3,12 +3,16 @@ package com.kyumall.kyumallclient.member;
 import com.kyumall.kyumallclient.exception.ErrorCode;
 import com.kyumall.kyumallclient.exception.KyumallException;
 import com.kyumall.kyumallclient.member.dto.SignUpRequest;
+import com.kyumall.kyumallclient.member.dto.TermDto;
 import com.kyumall.kyumallclient.member.dto.VerifySentCodeRequest;
 import com.kyumall.kyumallclient.member.dto.VerifySentCodeResult;
 import com.kyumall.kyumallclient.member.validator.SignUpRequestValidator;
+import com.kyumall.kyumallclient.response.ResponseWrapper;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -62,5 +66,14 @@ public class MemberController {
   @PostMapping("/sign-up")
   public void signUp(@RequestBody @Valid SignUpRequest request) {
     memberService.signUp(request);
+  }
+
+  /**
+   * 회원가입에 필요한 약관을 조회합니다.
+   * @return
+   */
+  @GetMapping("/sign-up-terms")
+  public ResponseWrapper<List<TermDto>> getSignUpTerms() {
+    return ResponseWrapper.ok(memberService.getSignUpTerms());
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/MemberService.java
@@ -4,6 +4,7 @@ import com.kyumall.kyumallclient.exception.ErrorCode;
 import com.kyumall.kyumallclient.exception.KyumallException;
 import com.kyumall.kyumallclient.member.dto.SignUpRequest;
 import com.kyumall.kyumallclient.member.dto.TermAndAgree;
+import com.kyumall.kyumallclient.member.dto.TermDto;
 import com.kyumall.kyumallclient.member.dto.VerifySentCodeRequest;
 import com.kyumall.kyumallclient.member.dto.VerifySentCodeResult;
 import com.kyumall.kyumallcommon.Util.RandomCodeGenerator;
@@ -146,5 +147,13 @@ public class MemberService {
       }
     }
     return Optional.empty();
+  }
+
+  /**
+   * 현재 '사용중' 상태인 모든 약관을 조회합니다.
+   */
+  public List<TermDto> getSignUpTerms() {
+    return termRepository.findAllTermsInUse()
+        .stream().map(TermDto::from).toList();
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/dto/TermDto.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/member/dto/TermDto.java
@@ -1,0 +1,24 @@
+package com.kyumall.kyumallclient.member.dto;
+
+import com.kyumall.kyumallcommon.member.entity.Term;
+import com.kyumall.kyumallcommon.member.vo.TermType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor @Builder
+public class TermDto {
+  private Long termId;
+  private String termName;
+  private String content;
+  private TermType type;
+
+  public static TermDto from(Term term) {
+    return TermDto.builder()
+        .termId(term.getId())
+        .termName(term.getName())
+        .content(term.getContent())
+        .type(term.getType())
+        .build();
+  }
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Term.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Term.java
@@ -1,9 +1,12 @@
 package com.kyumall.kyumallcommon.member.entity;
 
 import com.kyumall.kyumallcommon.BaseTimeEntity;
+import com.kyumall.kyumallcommon.member.vo.TermStatus;
 import com.kyumall.kyumallcommon.member.vo.TermType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -24,7 +27,10 @@ public class Term extends BaseTimeEntity {
   @Lob
   @Column(columnDefinition = "TEXT")
   private String content; // 약관 내용
+  @Enumerated(EnumType.STRING)
   private TermType type;
+  @Enumerated(EnumType.STRING)
+  private TermStatus status;  // 현재 사용중인지 여부
 
   /**
    * 해당 약관이 필수인지 반환합니다

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/repository/TermRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/repository/TermRepository.java
@@ -3,7 +3,15 @@ package com.kyumall.kyumallcommon.member.repository;
 import com.kyumall.kyumallcommon.member.entity.Term;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TermRepository extends JpaRepository<Term, Long> {
+  @Query("select t from Term t "
+      + "where t.id in :termIds "
+      + "and t.status = 'INUSE'")
   List<Term> findAllByIdIn(List<Long> termIds);
+
+  @Query("select t from Term t "
+      + "where t.status = 'INUSE'")
+  List<Term> findAllTermsInUse();
 }

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/vo/TermStatus.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/vo/TermStatus.java
@@ -1,0 +1,6 @@
+package com.kyumall.kyumallcommon.member.vo;
+
+public enum TermStatus {
+  INUSE, // 사용중
+  DELETED // 삭제됨
+}


### PR DESCRIPTION
## 변경 사항
약관 조회 로직 추가

## 상세 변경 사항
1. 약관 상태 추가
   > 약관 상태 (사용중, 삭제됨) 를 추가하였습니다.
   <img width="742" alt="image" src="https://github.com/f-lab-edu/kyumall/assets/78974381/37e326d5-efab-4a33-9e4f-712cd015f2ea">

<br/>

2. `사용중` 상태의 약관 조회 
   <img width="521" alt="image" src="https://github.com/f-lab-edu/kyumall/assets/78974381/237503f8-2328-4b9e-b31e-7cd0c522d887">


## 연관 이슈
- #4 