### PR TITLE
Feature/issue 15 상품추가,목록조회

### DIFF
--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/DataLoader.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/DataLoader.java
@@ -4,6 +4,9 @@ import com.kyumall.kyumallcommon.member.entity.Term;
 import com.kyumall.kyumallcommon.member.repository.TermRepository;
 import com.kyumall.kyumallcommon.member.vo.TermStatus;
 import com.kyumall.kyumallcommon.member.vo.TermType;
+import com.kyumall.kyumallcommon.product.entity.Category;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
+import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
@@ -17,9 +20,29 @@ import org.springframework.stereotype.Component;
 public class DataLoader implements CommandLineRunner {
 
   private final TermRepository termRepository;
+  private final CategoryRepository categoryRepository;
 
   @Override
   public void run(String... args) throws Exception {
+    saveTerms();
+    saveCategories();
+  }
+
+  private void saveCategories() {
+    Category food = Category.builder()
+        .name("식품")
+        .status(CategoryStatus.INUSE)
+        .build();
+    categoryRepository.save(food);
+    Category fruit = Category.builder()
+        .name("과일")
+        .parent(food)
+        .status(CategoryStatus.INUSE)
+        .build();
+    categoryRepository.save(fruit);
+  }
+
+  private void saveTerms() {
     Term kyumallTerm = Term.builder()
         .name("큐몰 이용약관")
         .content(

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/exception/ErrorCode.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/exception/ErrorCode.java
@@ -20,7 +20,11 @@ public enum ErrorCode {
   REQUIRED_TERM_MUST_AGREED("2005", "필수 약관은 반드시 동의해야합니다."),
   MEMBER_NOT_EXISTS("2006", "회원 정보가 존재하지 않습니다."),
   PASSWORD_AND_CONFIRM_NOT_EQUALS("2007", "비밀번호와 비밀번호 확인이 일치하지 않습니다."),
-  PASSWORD_NOT_MATCHED("2008", "비밀번호가 일치하지 않습니다.");
+  PASSWORD_NOT_MATCHED("2008", "비밀번호가 일치하지 않습니다."),
+
+  // 상품파트 에러 (3000 ~ 3999)
+  CATEGORY_NOT_EXISTS("3000", "카테고리가 존재하지 않습니다.");
+
 
   private final String code;
   private final String message;

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductController.java
@@ -1,0 +1,23 @@
+package com.kyumall.kyumallclient.product;
+
+import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
+import com.kyumall.kyumallclient.product.dto.CreateProductResponse;
+import com.kyumall.kyumallclient.response.ResponseWrapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RequestMapping("/products")
+@RestController
+public class ProductController {
+  private final ProductService productService;
+
+  @PostMapping
+  public ResponseWrapper<CreateProductResponse> createProduct(@RequestBody CreateProductRequest request) {
+    Long productId = productService.createProduct(request);
+    return ResponseWrapper.ok(new CreateProductResponse(productId));
+  }
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductController.java
@@ -2,8 +2,14 @@ package com.kyumall.kyumallclient.product;
 
 import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
 import com.kyumall.kyumallclient.product.dto.CreateProductResponse;
+import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
 import com.kyumall.kyumallclient.response.ResponseWrapper;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,5 +25,10 @@ public class ProductController {
   public ResponseWrapper<CreateProductResponse> createProduct(@RequestBody CreateProductRequest request) {
     Long productId = productService.createProduct(request);
     return ResponseWrapper.ok(new CreateProductResponse(productId));
+  }
+
+  @GetMapping
+  public ResponseWrapper<Page<ProductSimpleDto>> getAllProducts(@PageableDefault(size = 10) Pageable pageable) {
+    return ResponseWrapper.ok(productService.getAllProducts(pageable));
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -3,11 +3,14 @@ package com.kyumall.kyumallclient.product;
 import com.kyumall.kyumallclient.exception.ErrorCode;
 import com.kyumall.kyumallclient.exception.KyumallException;
 import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
+import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.entity.Product;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
 import com.kyumall.kyumallcommon.product.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -28,5 +31,9 @@ public class ProductService {
         .detail(request.getDetail())
         .build());
     return product.getId();
+  }
+
+  public Page<ProductSimpleDto> getAllProducts(Pageable pageable) {
+    return productRepository.findAllByOrderByName(pageable).map(ProductSimpleDto::from);
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -4,6 +4,8 @@ import com.kyumall.kyumallclient.exception.ErrorCode;
 import com.kyumall.kyumallclient.exception.KyumallException;
 import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
 import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
+import com.kyumall.kyumallcommon.member.entity.Member;
+import com.kyumall.kyumallcommon.member.repository.MemberRepository;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.entity.Product;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
@@ -19,14 +21,19 @@ public class ProductService {
 
   private final CategoryRepository categoryRepository;
   private final ProductRepository productRepository;
+  private final MemberRepository memberRepository;
 
   public Long createProduct(CreateProductRequest request) {
     Category category = categoryRepository.findById(request.getCategoryId())
         .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
 
+    Member seller = memberRepository.findByUsername(request.getSellerUsername())
+        .orElseThrow(() -> new KyumallException(ErrorCode.MEMBER_NOT_EXISTS));
+
     Product product = productRepository.save(Product.builder()
         .name(request.getProductName())
         .category(category)
+        .seller(seller)
         .price(request.getPrice())
         .detail(request.getDetail())
         .build());

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -1,0 +1,32 @@
+package com.kyumall.kyumallclient.product;
+
+import com.kyumall.kyumallclient.exception.ErrorCode;
+import com.kyumall.kyumallclient.exception.KyumallException;
+import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
+import com.kyumall.kyumallcommon.product.entity.Category;
+import com.kyumall.kyumallcommon.product.entity.Product;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
+import com.kyumall.kyumallcommon.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class ProductService {
+
+  private final CategoryRepository categoryRepository;
+  private final ProductRepository productRepository;
+
+  public Long createProduct(CreateProductRequest request) {
+    Category category = categoryRepository.findById(request.getCategoryId())
+        .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
+
+    Product product = productRepository.save(Product.builder()
+        .name(request.getProductName())
+        .category(category)
+        .price(request.getPrice())
+        .detail(request.getDetail())
+        .build());
+    return product.getId();
+  }
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductRequest.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductRequest.java
@@ -13,6 +13,8 @@ public class CreateProductRequest {
   private String productName;
   @NotNull
   private Long categoryId;
+  @NotEmpty
+  private String sellerUsername;
   @NotNull @Min(0)
   private Integer price;
   private String detail;

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductRequest.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductRequest.java
@@ -1,0 +1,19 @@
+package com.kyumall.kyumallclient.product.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor @Builder
+public class CreateProductRequest {
+  @NotEmpty
+  private String productName;
+  @NotNull
+  private Long categoryId;
+  @NotNull @Min(0)
+  private Integer price;
+  private String detail;
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductResponse.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CreateProductResponse.java
@@ -1,0 +1,9 @@
+package com.kyumall.kyumallclient.product.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter @AllArgsConstructor
+public class CreateProductResponse {
+  private Long id;
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/ProductSimpleDto.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/ProductSimpleDto.java
@@ -1,0 +1,23 @@
+package com.kyumall.kyumallclient.product.dto;
+
+import com.kyumall.kyumallcommon.product.entity.Product;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class ProductSimpleDto {
+  private String name;
+  private Integer price;
+  private String image;
+
+  public static ProductSimpleDto from(Product product) {
+    return ProductSimpleDto.builder()
+        .name(product.getName())
+        .price(product.getPrice())
+        .image(product.getImage())
+        .build();
+  }
+}

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/member/MemberFactory.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/member/MemberFactory.java
@@ -1,0 +1,25 @@
+package com.kyumall.kyumallclient.member;
+
+import com.kyumall.kyumallcommon.member.entity.Member;
+import com.kyumall.kyumallcommon.member.repository.MemberRepository;
+import com.kyumall.kyumallcommon.member.vo.MemberStatus;
+import com.kyumall.kyumallcommon.member.vo.MemberType;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MemberFactory {
+
+  @Autowired
+  MemberRepository memberRepository;
+
+  public Member createMember(String username, String email, String password, MemberType memberType) {
+    return memberRepository.saveAndFlush(Member.builder()
+            .username(username)
+            .email(email)
+            .password(password)
+            .status(MemberStatus.INUSE)
+            .type(memberType)
+        .build());
+  }
+}

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.kyumall.kyumallclient.IntegrationTest;
 import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
+import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.entity.Product;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
@@ -13,8 +14,9 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.http.HttpStatus;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,6 +32,10 @@ class ProductIntegrationTest extends IntegrationTest {
 
   Category food;
   Category fruit;
+  Category meet;
+  Product apple;
+  Product beef;
+  List<Product> allProducts = new ArrayList<>();
 
   @BeforeEach
   void initData() {
@@ -42,24 +48,31 @@ class ProductIntegrationTest extends IntegrationTest {
         .parent(food)
         .status(CategoryStatus.INUSE)
         .build());
+    meet = categoryRepository.save(Category.builder()
+        .name("육류")
+        .parent(food)
+        .status(CategoryStatus.INUSE)
+        .build());
+    apple = createProductForTest(new CreateProductRequest("얼음골사과", fruit.getId(), 40000,
+        "<h1>맛있는 사과</h1>"));
+    beef = createProductForTest(new CreateProductRequest("소고기", meet.getId(), 50000,
+        "<h1>맛있는 소고기</h1>"));
+    allProducts.add(apple);
+    allProducts.add(beef);
   }
 
   @Test
   @DisplayName("상품 생성에 성공합니다.")
   void createProduct_success() {
-    // givne
+    // given
     CreateProductRequest request = CreateProductRequest.builder()
         .productName("얼음골 사과")
         .categoryId(fruit.getId())
         .price(30000)
         .detail("사과입니다.").build();
     // when
-    ExtractableResponse<Response> response = RestAssured.given().log().all()
-        .contentType(ContentType.JSON)
-        .body(request)
-        .when().post("/products")
-        .then().log().all()
-        .extract();
+    ExtractableResponse<Response> response = requestCreateProduct(
+        request);
 
     // then
     assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
@@ -69,6 +82,44 @@ class ProductIntegrationTest extends IntegrationTest {
     assertThat(savedProduct.getCategory().getId()).isEqualTo(request.getCategoryId());
     assertThat(savedProduct.getPrice()).isEqualTo(request.getPrice());
     assertThat(savedProduct.getDetail()).isEqualTo(request.getDetail());
+  }
+
+  @Test
+  @DisplayName("상품리스트 조회에 성공합니다.")
+  void getAllProducts_success() {
+    //given
+    //when
+    ExtractableResponse<Response> response = RestAssured.given().log().all()
+        .when().get("/products")
+        .then().log().all()
+        .extract();
+    //then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    // 페이징 검증
+    assertThat((Integer)response.body().jsonPath().get("result.size")).isEqualTo(10);
+    assertThat((Integer)response.body().jsonPath().get("result.number")).isEqualTo(0);
+    // 조회 결과 검증
+    List<ProductSimpleDto> result = response.body().jsonPath().getList("result.content", ProductSimpleDto.class);
+    assertThat(result).hasSize(2);
+    for (ProductSimpleDto dto: result) {
+      assertThat(dto).usingRecursiveComparison().comparingOnlyFields("name", "price", "image").isIn(allProducts);
+    }
+  }
+
+  private Product createProductForTest(CreateProductRequest request) {
+    Integer newProductId = requestCreateProduct(request).body().jsonPath().get("result.id");
+    return findProductById(newProductId.longValue());
+  }
+
+  private static ExtractableResponse<Response> requestCreateProduct(
+      CreateProductRequest request) {
+    ExtractableResponse<Response> response = RestAssured.given().log().all()
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when().post("/products")
+        .then().log().all()
+        .extract();
+    return response;
   }
 
   private Product findProductById(Long productId) {

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
@@ -1,0 +1,78 @@
+package com.kyumall.kyumallclient.product;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.kyumall.kyumallclient.IntegrationTest;
+import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
+import com.kyumall.kyumallcommon.product.entity.Category;
+import com.kyumall.kyumallcommon.product.entity.Product;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
+import com.kyumall.kyumallcommon.product.repository.ProductRepository;
+import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.apache.http.HttpStatus;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("상품 통합테스트")
+class ProductIntegrationTest extends IntegrationTest {
+
+  @Autowired
+  private CategoryRepository categoryRepository;
+  @Autowired
+  private ProductRepository productRepository;
+
+  Category food;
+  Category fruit;
+
+  @BeforeEach
+  void initData() {
+    food = categoryRepository.save(Category.builder()
+        .name("식품")
+        .status(CategoryStatus.INUSE)
+        .build());
+    fruit = categoryRepository.save(Category.builder()
+        .name("과일")
+        .parent(food)
+        .status(CategoryStatus.INUSE)
+        .build());
+  }
+
+  @Test
+  @DisplayName("상품 생성에 성공합니다.")
+  void createProduct_success() {
+    // givne
+    CreateProductRequest request = CreateProductRequest.builder()
+        .productName("얼음골 사과")
+        .categoryId(fruit.getId())
+        .price(30000)
+        .detail("사과입니다.").build();
+    // when
+    ExtractableResponse<Response> response = RestAssured.given().log().all()
+        .contentType(ContentType.JSON)
+        .body(request)
+        .when().post("/products")
+        .then().log().all()
+        .extract();
+
+    // then
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    Integer createdId = response.body().jsonPath().get("result.id");
+    Product savedProduct = findProductById(createdId.longValue());
+    assertThat(savedProduct.getName()).isEqualTo(request.getProductName());
+    assertThat(savedProduct.getCategory().getId()).isEqualTo(request.getCategoryId());
+    assertThat(savedProduct.getPrice()).isEqualTo(request.getPrice());
+    assertThat(savedProduct.getDetail()).isEqualTo(request.getDetail());
+  }
+
+  private Product findProductById(Long productId) {
+    return productRepository.findById(productId)
+        .orElseThrow(() -> new RuntimeException());
+  }
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Term.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/entity/Term.java
@@ -23,13 +23,13 @@ public class Term extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  private String groupName; // 약관 그룹명 (영문)
-  private Integer version;  // 버전
+  //private String groupName; // 약관 그룹명 (영문)
+  //private Integer version;  // 버전
   private String name;  // 약관명
   @Lob
   @Column(columnDefinition = "TEXT")
   private String content; // 약관 내용
-  private Integer order;  // 약관 정렬 순서
+  //private Integer order;  // 약관 정렬 순서
   @Enumerated(EnumType.STRING)
   private TermType type;
   @Enumerated(EnumType.STRING)

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/vo/MemberType.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/member/vo/MemberType.java
@@ -3,5 +3,5 @@ package com.kyumall.kyumallcommon.member.vo;
 
 public enum MemberType {
   USER,   // 유저
-  ADMIN   // 관리자
+  SELLER  // 판매자
 }

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Category.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Category.java
@@ -1,0 +1,40 @@
+package com.kyumall.kyumallcommon.product.entity;
+
+import com.kyumall.kyumallcommon.BaseTimeEntity;
+import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor @Builder
+@Entity
+public class Category extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String name;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_id")
+  private Category parent;
+  @Enumerated(value = EnumType.STRING)
+  private CategoryStatus status;
+  @OneToMany(mappedBy = "parent")
+  private List<Category> child = new ArrayList<>();
+  @OneToMany(mappedBy = "category")
+  private List<Product> products;
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Product.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Product.java
@@ -3,6 +3,7 @@ package com.kyumall.kyumallcommon.product.entity;
 import com.kyumall.kyumallcommon.BaseTimeEntity;
 import com.kyumall.kyumallcommon.member.entity.Member;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -20,9 +21,12 @@ public class Product extends BaseTimeEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
-  @ManyToOne
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "category_id")
   private Category category;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "seller_id")
+  private Member seller;
   private String name;
   private Integer price;
   private String image;

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Product.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Product.java
@@ -1,0 +1,30 @@
+package com.kyumall.kyumallcommon.product.entity;
+
+import com.kyumall.kyumallcommon.BaseTimeEntity;
+import com.kyumall.kyumallcommon.member.entity.Member;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor @AllArgsConstructor @Builder
+@Entity
+public class Product extends BaseTimeEntity {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  @JoinColumn(name = "category_id")
+  private Category category;
+  private String name;
+  private Integer price;
+  private String image;
+  private String detail;
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
@@ -1,0 +1,8 @@
+package com.kyumall.kyumallcommon.product.repository;
+
+import com.kyumall.kyumallcommon.product.entity.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/ProductRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/ProductRepository.java
@@ -1,8 +1,12 @@
 package com.kyumall.kyumallcommon.product.repository;
 
 import com.kyumall.kyumallcommon.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long> {
-
+  @EntityGraph(attributePaths = {"category"})
+  Page<Product> findAllByOrderByName(Pageable pageable);
 }

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/ProductRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/ProductRepository.java
@@ -1,0 +1,8 @@
+package com.kyumall.kyumallcommon.product.repository;
+
+import com.kyumall.kyumallcommon.product.entity.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProductRepository extends JpaRepository<Product, Long> {
+
+}

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/vo/CategoryStatus.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/vo/CategoryStatus.java
@@ -1,0 +1,5 @@
+package com.kyumall.kyumallcommon.product.vo;
+
+public enum CategoryStatus {
+  INUSE, DELETED
+}

--- a/kyumall-common/src/main/resources/truncate.sql
+++ b/kyumall-common/src/main/resources/truncate.sql
@@ -4,3 +4,5 @@ TRUNCATE TABLE member;
 TRUNCATE TABLE verification;
 TRUNCATE TABLE term;
 TRUNCATE TABLE agreement;
+TRUNCATE TABLE category;
+TRUNCATE TABLE product;


### PR DESCRIPTION
## 변경사항
> 상품(`Product`) 도메인 구현을 시작하였습니다. 아래 기능을 추가하였습니다.
- 상품 엔티티 추가
- 상품 추가 
- 상품 목록 조회

## 상세 변경사항
- 카테고리(`Category`), 상품 엔티티(`Product`)추가
- 상품 추가 (`POST /products`)
-  상품 목록 조회 (`GET /products`)
   - 페이징 하여 반환 
   - 조회 시, `Category`와  N+1 문제 발생하여 `EntityGraph`추가

## 연관 이슈
- #15 