### PR TITLE
[#20] refactor: 카테고리 서비스 분리 (cacheManager 직접 사용하지 않도록 변경)

### DIFF
--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -21,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class CategoryController {
   private final ProductService productService;
+  private final CategoryService categoryService;
 
   /**
    * 전체 카테고리를 조회합니다.
@@ -28,7 +29,7 @@ public class CategoryController {
    */
   @GetMapping
   public ResponseWrapper<List<CategoryDto>> getAllCategories() {
-    Map<Long, List<Category>> categoryGroupingByParent = productService.findCategoryGroupingByParent();
+    Map<Long, List<Category>> categoryGroupingByParent = categoryService.findCategoryGroupingByParent();
     return ResponseWrapper.ok(convertToCategoryHierarchy(categoryGroupingByParent));
   }
 

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
@@ -1,0 +1,35 @@
+package com.kyumall.kyumallclient.product;
+
+import com.kyumall.kyumallcommon.exception.ErrorCode;
+import com.kyumall.kyumallcommon.exception.KyumallException;
+import com.kyumall.kyumallcommon.product.entity.Category;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
+import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CategoryService {
+  private final CategoryRepository categoryRepository;
+
+  //캐시는 히트율이 중요함 id 별로 카테고리를 캐시하지 말고, 전체 카테고리를 캐시해 둘 것
+  public Category findCategoryById(Long categoryId) {
+    return categoryRepository.findById(categoryId)
+        .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
+  }
+
+  /**
+   * 전체 카테고리를 조회하여 parentId 로 group by 한 Map 을 만듭니다.
+   * @return all category grouping by parent id
+   */
+  @Cacheable(value = "categoryMap", key = "#root.methodName")
+  public Map<Long, List<Category>> findCategoryGroupingByParent() {
+    List<Category> allCategory = categoryRepository.findAllByStatus(CategoryStatus.INUSE);
+    return allCategory.stream().collect(Collectors.groupingBy(Category::getParentId));
+  }
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -1,6 +1,5 @@
 package com.kyumall.kyumallclient.product;
 
-import com.kyumall.kyumallcommon.exception.CacheNotFoundException;
 import com.kyumall.kyumallcommon.exception.ErrorCode;
 import com.kyumall.kyumallcommon.exception.KyumallException;
 import com.kyumall.kyumallclient.product.dto.CreateProductRequest;
@@ -11,16 +10,10 @@ import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.entity.Product;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
 import com.kyumall.kyumallcommon.product.repository.ProductRepository;
-import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.Cache;
-import org.springframework.cache.Cache.ValueWrapper;
-import org.springframework.cache.CacheManager;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,14 +22,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
-
-  private final CategoryRepository categoryRepository;
+  private final CategoryService categoryService;
   private final ProductRepository productRepository;
   private final MemberRepository memberRepository;
-  private final CacheManager cacheManager;
 
   public Long createProduct(CreateProductRequest request) {
-    Category category = findCategoryById(request.getCategoryId());
+    Category category = categoryService.findCategoryById(request.getCategoryId());
 
     Member seller = memberRepository.findByUsername(request.getSellerUsername())
         .orElseThrow(() -> new KyumallException(ErrorCode.MEMBER_NOT_EXISTS));
@@ -56,22 +47,6 @@ public class ProductService {
   }
 
   /**
-   * 전체 카테고리를 조회하여 parentId 로 group by 한 Map 을 만듭니다.
-   * @return all category grouping by parent id
-   */
-  @Cacheable(value = "categoryMap", key = "#root.methodName")
-  public Map<Long, List<Category>> findCategoryGroupingByParent() {
-    List<Category> allCategory = categoryRepository.findAllByStatus(CategoryStatus.INUSE);
-    return allCategory.stream().collect(Collectors.groupingBy(Category::getParentId));
-  }
-
-  //캐시는 히트율이 중요함 id 별로 카테고리를 캐시하지 말고, 전체 카테고리를 캐시해 둘 것
-  private Category findCategoryById(Long categoryId) {
-    return categoryRepository.findById(categoryId)
-        .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
-  }
-
-  /**
    * 카테고리에 해당하는 아이템을 조회합니다.
    * 입력받은 카테고리의 하위 카테고리에 해당하는 상품까지 조회합니다.
    * ex) 입력받은 카테고리 : 식품 -> 과일, 육류 카테고리의 상품까지 조회됨
@@ -81,34 +56,27 @@ public class ProductService {
    */
   public Slice<ProductSimpleDto> getProductsInCategory(Long categoryId, Pageable pageable) {
     List<Long> subCategoryIds;
-    try {
-      subCategoryIds = getSubCategoriesFromCache(categoryId);
-    } catch (CacheNotFoundException e) {
-      subCategoryIds = categoryRepository.findSubCategoryIds(categoryId);
-    }
+    subCategoryIds = findSubCategories(categoryId);
     subCategoryIds.add(categoryId);
     return productRepository.findByCategoryIds(subCategoryIds, pageable).map(ProductSimpleDto::from);
   }
 
   /**
+   * 주어진 카테고리의 하위 카테고리를 조회합니다.
    * 캐시에 저장된 categoryMap 에서 categoryId 의 서브 카테고리를 조회합니다.
    * 재귀적으로 조회
    * @param categoryId
    * @return
    */
-  private List<Long> getSubCategoriesFromCache(Long categoryId) throws CacheNotFoundException {
-    Cache categoryMapCache = cacheManager.getCache("categoryMap");
-    if (categoryMapCache != null) {
-      ValueWrapper valueWrapper = categoryMapCache.get("findCategoryGroupingByParent");
-      if (valueWrapper != null) {
-        Map<Long, List<Category>> categoryMap = (Map<Long, List<Category>>)valueWrapper.get();
-        List<Category> categories = categoryMap.get(categoryId);
-        List<Long> allSubCategories = new ArrayList<>();
-        recursiveSetSubCategories(categories, categoryMap, allSubCategories);
-        return allSubCategories;
-      }
+  private List<Long> findSubCategories(Long categoryId) {
+    Map<Long, List<Category>> categoryGroupingByParent = categoryService.findCategoryGroupingByParent();
+    if(!categoryGroupingByParent.containsKey(categoryId)) {
+      throw new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS);
     }
-    throw new CacheNotFoundException("categoryMap 캐시를 찾을 수 없습니다.");
+    List<Category> categories = categoryGroupingByParent.get(categoryId);
+    List<Long> allSubCategories = new ArrayList<>();
+    recursiveSetSubCategories(categories, categoryGroupingByParent, allSubCategories);
+    return allSubCategories;
   }
 
   void recursiveSetSubCategories(List<Category> categories, Map<Long, List<Category>> categoryMap, List<Long> allSubCategories) {


### PR DESCRIPTION
## 상황
- 서브 카테고리 조회시, 캐싱된 map 형태의 전체 카테고리를 조회하는 로직
- 문제: Spring AOP로 동작하는 스프링 캐시의 특성상 내부 메서드 호출시 캐시가 되지 않음

## AS-IS
cacheManager 를 호출하여 직접 캐싱된 전체 카테고리를 가져옴

## 변경
TO-BE: 클래스를 리팩토링 하여 서로 다른 서비스에서 호출되어 캐싱된 데이터를 가져올 수 있도록 변경