### PR TITLE
Feature/issue 53 카테고리 파트 보완

### DIFF
--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -46,7 +46,7 @@ public class CategoryController {
   }
 
   /**
-   * 재귀 호출로 카테고리의 서브 카테고리를 추가
+   * 재귀 호출로 카테고리의 서브 카테고리를 계층형으로 추가합니다.
    * @param categoryDtos
    * @param groupingByParentId
    */

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -5,6 +5,7 @@ import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
 import com.kyumall.kyumallclient.product.dto.SubCategoryDto;
 import com.kyumall.kyumallcommon.response.ResponseWrapper;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -22,12 +23,21 @@ public class CategoryController {
   private final CategoryService categoryService;
 
   /**
-   * 전체 카테고리를 조회합니다.
+   * 전체 카테고리를 조회합니다. (계층형 리스트 형태)
    * @return
    */
   @GetMapping("/hierarchy")
   public ResponseWrapper<List<CategoryDto>> getAllCategoriesHierarchy() {
-    return ResponseWrapper.ok(categoryService.getAllCategories());
+    return ResponseWrapper.ok(categoryService.getAllCategoriesHierarchy());
+  }
+
+  /**
+   * 전체 카테고리를 조회합니다. (맵 형태)
+   * @return
+   */
+  @GetMapping("/map")
+  public ResponseWrapper<Map<Long, List<SubCategoryDto>>> getAllCategoriesMap() {
+    return ResponseWrapper.ok(categoryService.getAllCategoriesMap());
   }
 
   /**

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -2,11 +2,8 @@ package com.kyumall.kyumallclient.product;
 
 import com.kyumall.kyumallclient.product.dto.CategoryDto;
 import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
-import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.response.ResponseWrapper;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -29,37 +26,10 @@ public class CategoryController {
    */
   @GetMapping
   public ResponseWrapper<List<CategoryDto>> getAllCategories() {
-    Map<Long, List<Category>> categoryGroupingByParent = categoryService.findCategoryGroupingByParent();
-    return ResponseWrapper.ok(convertToCategoryHierarchy(categoryGroupingByParent));
+    return ResponseWrapper.ok(categoryService.getAllCategories());
   }
 
-  /**
-   * 카테고리 Map을 계층형 구조의 List로 변경
-   * @param groupingByParentId
-   * @return
-   */
-  private List<CategoryDto> convertToCategoryHierarchy(Map<Long, List<Category>> groupingByParentId) {
-    List<CategoryDto> rootCategories = groupingByParentId.get(0L).stream().map(CategoryDto::from)
-        .toList();
-    addSubCategories(rootCategories, groupingByParentId);
-    return rootCategories;
-  }
 
-  /**
-   * 재귀 호출로 카테고리의 서브 카테고리를 계층형으로 추가합니다.
-   * @param categoryDtos
-   * @param groupingByParentId
-   */
-  private void addSubCategories(List<CategoryDto> categoryDtos, Map<Long, List<Category>> groupingByParentId) {
-    categoryDtos.stream().forEach(
-        categoryDto -> {
-          List<CategoryDto> subCategories = groupingByParentId.getOrDefault(categoryDto.getId(), new ArrayList<>())
-              .stream().map(CategoryDto::from).toList();
-          categoryDto.setSubCategories(subCategories);
-          addSubCategories(subCategories, groupingByParentId);
-        }
-    );
-  }
 
   /**
    * 카테고리에 해당하는 상품 목록을 조회합니다.

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -25,8 +25,8 @@ public class CategoryController {
    * 전체 카테고리를 조회합니다.
    * @return
    */
-  @GetMapping
-  public ResponseWrapper<List<CategoryDto>> getAllCategories() {
+  @GetMapping("/hierarchy")
+  public ResponseWrapper<List<CategoryDto>> getAllCategoriesHierarchy() {
     return ResponseWrapper.ok(categoryService.getAllCategories());
   }
 

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryController.java
@@ -2,6 +2,7 @@ package com.kyumall.kyumallclient.product;
 
 import com.kyumall.kyumallclient.product.dto.CategoryDto;
 import com.kyumall.kyumallclient.product.dto.ProductSimpleDto;
+import com.kyumall.kyumallclient.product.dto.SubCategoryDto;
 import com.kyumall.kyumallcommon.response.ResponseWrapper;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,15 @@ public class CategoryController {
     return ResponseWrapper.ok(categoryService.getAllCategories());
   }
 
-
+  /**
+   * 카테고리 ID의 한단계 아래 서브 카테고리 목록을를 조회합니다.
+   * 한단계 아래의 서브 카테고리만 조회합니다.
+   * @return
+   */
+  @GetMapping("/{id}/subCategories")
+  public ResponseWrapper<List<SubCategoryDto>> getOneStepSubCategories(@PathVariable Long id) {
+    return ResponseWrapper.ok(categoryService.getOneStepSubCategories(id));
+  }
 
   /**
    * 카테고리에 해당하는 상품 목록을 조회합니다.

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryMapService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryMapService.java
@@ -1,0 +1,28 @@
+package com.kyumall.kyumallclient.product;
+
+import com.kyumall.kyumallcommon.product.entity.Category;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
+import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryMapService {
+  private final CategoryRepository categoryRepository;
+  /**
+   * 전체 카테고리를 조회하여 parentId 로 group by 한 Map 을 만듭니다.
+   * 캐시는 히트율이 중요함 id 별로 카테고리를 캐시하지 말고, 전체 카테고리를 캐시해 둘 것
+   * @return all category grouping by parent id
+   */
+  @Cacheable(value = "categoryMap", key = "#root.methodName")
+  public Map<Long, List<Category>> findCategoryGroupingByParent() {
+    List<Category> allCategory = categoryRepository.findAllByStatus(CategoryStatus.INUSE);
+    return allCategory.stream().collect(Collectors.groupingBy(Category::getParentId));
+  }
+
+}

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
@@ -7,6 +7,7 @@ import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,9 +17,28 @@ public class CategoryService {
   private final CategoryMapService categoryMapService;
   private final CategoryRepository categoryRepository;
 
-  public List<CategoryDto> getAllCategories() {
+  /**
+   * 전체 카테고리를 계층형 리스트 형태로 조회
+   * @return
+   */
+  public List<CategoryDto> getAllCategoriesHierarchy() {
     Map<Long, List<Category>> categoryGroupingByParent = categoryMapService.findCategoryGroupingByParent();
     return convertToCategoryHierarchy(categoryGroupingByParent);
+  }
+
+  /**
+   * 전체 카테고리를 맵 형태로 조회
+   * @return
+   */
+  public Map<Long, List<SubCategoryDto>> getAllCategoriesMap() {
+    Map<Long, List<Category>> categoryGroupingByParent = categoryMapService.findCategoryGroupingByParent();
+    return categoryGroupingByParent.entrySet().stream()
+        .collect(Collectors.toMap(
+            Map.Entry::getKey,  // 키는 변경 없이 유지
+            entry -> entry.getValue().stream()
+                .map(category -> SubCategoryDto.from(category, categoryGroupingByParent.containsKey(category.getId())))
+                .collect(Collectors.toList())
+        ));
   }
 
 

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
@@ -1,6 +1,7 @@
 package com.kyumall.kyumallclient.product;
 
 import com.kyumall.kyumallclient.product.dto.CategoryDto;
+import com.kyumall.kyumallclient.product.dto.SubCategoryDto;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
 import java.util.ArrayList;
@@ -47,5 +48,22 @@ public class CategoryService {
           addSubCategories(subCategories, groupingByParentId);
         }
     );
+  }
+
+  /**
+   * 서브 카테고리를 조회합니다.
+   * 한단계 아래 자식 서브 카테고리만 조회합니다.
+   * @param id
+   * @return
+   */
+  public List<SubCategoryDto> getOneStepSubCategories(Long id) {
+    Map<Long, List<Category>> categoryGroupingByParent = categoryMapService.findCategoryGroupingByParent();
+    if (!categoryGroupingByParent.containsKey(id)) {
+      return new ArrayList<>();
+    }
+    return categoryGroupingByParent.get(id)
+        .stream()
+        .map(category -> SubCategoryDto.from(category, categoryGroupingByParent.containsKey(category.getId())))
+        .toList();
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/CategoryService.java
@@ -1,35 +1,51 @@
 package com.kyumall.kyumallclient.product;
 
-import com.kyumall.kyumallcommon.exception.ErrorCode;
-import com.kyumall.kyumallcommon.exception.KyumallException;
+import com.kyumall.kyumallclient.product.dto.CategoryDto;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
-import com.kyumall.kyumallcommon.product.vo.CategoryStatus;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
 public class CategoryService {
+  private final CategoryMapService categoryMapService;
   private final CategoryRepository categoryRepository;
 
-  //캐시는 히트율이 중요함 id 별로 카테고리를 캐시하지 말고, 전체 카테고리를 캐시해 둘 것
-  public Category findCategoryById(Long categoryId) {
-    return categoryRepository.findById(categoryId)
-        .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
+  public List<CategoryDto> getAllCategories() {
+    Map<Long, List<Category>> categoryGroupingByParent = categoryMapService.findCategoryGroupingByParent();
+    return convertToCategoryHierarchy(categoryGroupingByParent);
+  }
+
+
+  /**
+   * 카테고리 Map을 계층형 구조의 List로 변경
+   * @param groupingByParentId
+   * @return
+   */
+  private List<CategoryDto> convertToCategoryHierarchy(Map<Long, List<Category>> groupingByParentId) {
+    List<CategoryDto> rootCategories = groupingByParentId.get(0L).stream().map(CategoryDto::from)
+        .toList();
+    addSubCategories(rootCategories, groupingByParentId);
+    return rootCategories;
   }
 
   /**
-   * 전체 카테고리를 조회하여 parentId 로 group by 한 Map 을 만듭니다.
-   * @return all category grouping by parent id
+   * 재귀 호출로 카테고리의 서브 카테고리를 계층형으로 추가합니다.
+   * @param categoryDtos
+   * @param groupingByParentId
    */
-  @Cacheable(value = "categoryMap", key = "#root.methodName")
-  public Map<Long, List<Category>> findCategoryGroupingByParent() {
-    List<Category> allCategory = categoryRepository.findAllByStatus(CategoryStatus.INUSE);
-    return allCategory.stream().collect(Collectors.groupingBy(Category::getParentId));
+  private void addSubCategories(List<CategoryDto> categoryDtos, Map<Long, List<Category>> groupingByParentId) {
+    categoryDtos.stream().forEach(
+        categoryDto -> {
+          List<CategoryDto> subCategories = groupingByParentId.getOrDefault(categoryDto.getId(), new ArrayList<>())
+              .stream().map(CategoryDto::from).toList();
+          categoryDto.setSubCategories(subCategories);
+          addSubCategories(subCategories, groupingByParentId);
+        }
+    );
   }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -9,6 +9,7 @@ import com.kyumall.kyumallcommon.member.entity.Member;
 import com.kyumall.kyumallcommon.member.repository.MemberRepository;
 import com.kyumall.kyumallcommon.product.entity.Category;
 import com.kyumall.kyumallcommon.product.entity.Product;
+import com.kyumall.kyumallcommon.product.repository.CategoryRepository;
 import com.kyumall.kyumallcommon.product.repository.ProductRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -22,7 +23,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ProductService {
-  private final CategoryService categoryService;
+  private final CategoryMapService categoryMapService;
+  private final CategoryRepository categoryRepository;
   private final ProductRepository productRepository;
   private final MemberRepository memberRepository;
 
@@ -32,7 +34,8 @@ public class ProductService {
    * @return
    */
   public Long createProduct(CreateProductRequest request) {
-    Category category = categoryService.findCategoryById(request.getCategoryId());
+    Category category = categoryRepository.findById(request.getCategoryId())
+        .orElseThrow(() -> new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS));
 
     Member seller = memberRepository.findByUsername(request.getSellerUsername())
         .orElseThrow(() -> new KyumallException(ErrorCode.MEMBER_NOT_EXISTS));
@@ -79,7 +82,7 @@ public class ProductService {
    * @return
    */
   private List<Long> findAllSubCategories(Long categoryId) {
-    Map<Long, List<Category>> categoryGroupingByParent = categoryService.findCategoryGroupingByParent();
+    Map<Long, List<Category>> categoryGroupingByParent = categoryMapService.findCategoryGroupingByParent();
     if(!categoryGroupingByParent.containsKey(categoryId)) {
       throw new KyumallException(ErrorCode.CATEGORY_NOT_EXISTS);
     }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/ProductService.java
@@ -91,9 +91,4 @@ public class ProductService {
     return ProductDetailDto.from(productRepository.findWithSellerById(id)
         .orElseThrow(() -> new KyumallException(ErrorCode.PRODUCT_NOT_EXISTS)));
   }
-
-  private Product findProduct(Long id) {
-    return productRepository.findById(id)
-        .orElseThrow(() -> new KyumallException(ErrorCode.PRODUCT_NOT_EXISTS));
-  }
 }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CategoryDto.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/CategoryDto.java
@@ -10,13 +10,16 @@ public class CategoryDto {
   private Long id;
   private String name;
   private List<CategoryDto> subCategories = new ArrayList<>();
+
   public CategoryDto(Long id, String name) {
     this.id = id;
     this.name = name;
   }
+
   public static CategoryDto from(Category category) {
     return new CategoryDto(category.getId(), category.getName());
   }
+
   public void setSubCategories(List<CategoryDto> subCategories) {
     this.subCategories = subCategories;
   }

--- a/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/SubCategoryDto.java
+++ b/kyumall-client/src/main/java/com/kyumall/kyumallclient/product/dto/SubCategoryDto.java
@@ -1,0 +1,23 @@
+package com.kyumall.kyumallclient.product.dto;
+
+import com.kyumall.kyumallcommon.product.entity.Category;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@AllArgsConstructor
+@Getter
+public class SubCategoryDto {
+  private Long id;
+  private String name;
+  private Boolean subCategoryExists;  // 하위 카테고리가 존재하는지 (true 시, 열림 버튼 활성화)
+
+  public static SubCategoryDto from(Category category, boolean isSubCategoryExists) {
+    return SubCategoryDto.builder()
+        .id(category.getId())
+        .name(category.getName())
+        .subCategoryExists(isSubCategoryExists)
+        .build();
+  }
+}

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/IntegrationTest.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/IntegrationTest.java
@@ -2,8 +2,12 @@ package com.kyumall.kyumallclient;
 
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -14,8 +18,19 @@ public abstract class IntegrationTest {
   @LocalServerPort
   int port;
 
+  @Autowired
+  private CacheManager cacheManager;
+
   @BeforeEach
   public void setUp() {
     RestAssured.port = port;
+
+    // 캐시 비우기
+    cacheManager.getCacheNames().forEach(cacheName -> {
+      Cache cache = cacheManager.getCache(cacheName);
+      if (cache != null) {
+        cache.clear();
+      }
+    });
   }
 }

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
@@ -27,6 +27,7 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.http.HttpStatus;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -113,8 +114,8 @@ public class ProductIntegrationTest extends IntegrationTest {
   }
 
   @Test
-  @DisplayName("모든 카테고리를 조회합니다.")
-  void getAllCategories_success() {
+  @DisplayName("모든 카테고리를 계층형 리스트 형태로 조회합니다.")
+  void getAllCategoriesHierarchy_success() {
     Category houseItem = saveCategory("생활용품", null);
     Category toiletPaper = saveCategory("화장지", houseItem);
     Category wetWipe = saveCategory("물티슈", toiletPaper);
@@ -132,6 +133,24 @@ public class ProductIntegrationTest extends IntegrationTest {
     assertThat(categories.get(0).getSubCategories().get(0).getName()).isEqualTo("화장지");
     assertThat(categories.get(0).getSubCategories().get(0).getSubCategories().get(0).getName()).isEqualTo("물티슈");
     assertThat(categories.get(0).getSubCategories().get(0).getSubCategories().get(1).getName()).isEqualTo("키친타올");
+  }
+
+  @Test
+  @DisplayName("모든 카테고리를 맵 형태로 조회합니다.")
+  void getAllCategoriesMap_success() {
+    Category houseItem = saveCategory("생활용품", null);
+    Category toiletPaper = saveCategory("화장지", houseItem);
+    Category wetWipe = saveCategory("물티슈", toiletPaper);
+    Category paperTowel = saveCategory("키친타올", toiletPaper);
+
+    ExtractableResponse<Response> response = RestAssured.given().log().all()
+        .when().get("/categories/map")
+        .then().log().all()
+        .extract();
+
+    assertThat(response.statusCode()).isEqualTo(HttpStatus.SC_OK);
+    Map<Long, List> categoryMap = response.body().jsonPath().getMap("result", Long.class, List.class);
+    assertThat(categoryMap.size()).isEqualTo(3);
   }
 
   @Test

--- a/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
+++ b/kyumall-client/src/test/java/com/kyumall/kyumallclient/product/ProductIntegrationTest.java
@@ -121,7 +121,7 @@ public class ProductIntegrationTest extends IntegrationTest {
     Category paperTowel = saveCategory("키친타올", toiletPaper);
 
     ExtractableResponse<Response> response = RestAssured.given().log().all()
-        .when().get("/categories")
+        .when().get("/categories/hierarchy")
         .then().log().all()
         .extract();
 
@@ -143,12 +143,12 @@ public class ProductIntegrationTest extends IntegrationTest {
     Category paperTowel = saveCategory("키친타올", toiletPaper);
 
     RestAssured.given().log().all()
-        .when().get("/categories")
+        .when().get("/categories/hierarchy")
         .then().log().all()
         .extract();
 
     ExtractableResponse<Response> response = RestAssured.given().log().all()
-        .when().get("/categories")
+        .when().get("/categories/hierarchy")
         .then().log().all()
         .extract();
 

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Category.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/entity/Category.java
@@ -36,6 +36,7 @@ public class Category extends BaseTimeEntity {
 
   @Enumerated(value = EnumType.STRING)
   private CategoryStatus status;
+
   @OneToMany(mappedBy = "category")
   private List<Product> products;
 

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
@@ -15,6 +15,14 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
 
   Optional<Category> findByName(String name);
 
+  /**
+   * 카테고리ID 로 서브 카테고리를 조회합니다.
+   *
+   * @deprecated 전체 카테고리를 캐시하도록 변경하여, 현재 사용하지 않습니다.
+   * @param categoryId
+   * @return
+   */
+  @Deprecated
   @Query(
       value = "WITH RECURSIVE cte AS ("
           + "  SELECT id, parent_id, name, 0 as depth from category c "
@@ -25,5 +33,5 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
           + ") "
           + "SELECT id from cte "
   , nativeQuery = true)
-  List<Long> findSubCategoryIds(Long categoryId);
+  List<Long> findSubCategoryById(Long categoryId);
 }

--- a/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
+++ b/kyumall-common/src/main/java/com/kyumall/kyumallcommon/product/repository/CategoryRepository.java
@@ -13,8 +13,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
   @EntityGraph(attributePaths = {"parent"})
   List<Category> findAllByStatus(CategoryStatus status);
 
-  Optional<Category> findByName(String name);
-
   /**
    * 카테고리ID 로 서브 카테고리를 조회합니다.
    *


### PR DESCRIPTION
# 개요 
카테고리 관련 기능 중 부족한 기능을 추가하고, 코드를 리팩토링 합니다.

# 변경 사항
- 기능 추가
  - 카테고리 조회 API (Map 반환 타입) : `GET /categories/map`
  - 하위 카테고리 조회 API : `GET categories/{id}/subCategories`
- 변경 사항
  - 카테고리 조회 API endpoint 변경: `GET /categories` -> ` GET/categories/hierarchy`
  - 전체 카테고리 캐시용 서비스(CategoryMapService) 생성 (AOP를 사용하여 캐시 주입이 되는 스프링의 특성상, CategoryService와 분리)
  - 테스트간, 캐시된 데이터가 공유되는 문제를 해결하기 위해 `@BeforeEach` 에 캐시 삭제하는 기능 추가